### PR TITLE
Adding support for infinite dimension and updating base protocol naming

### DIFF
--- a/src/hypergrid/dsl.py
+++ b/src/hypergrid/dsl.py
@@ -1,4 +1,4 @@
-from hypergrid.dimension import Dimension
-from hypergrid.grid import Grid
+from hypergrid.dimension import Dimension, FDimension, IDimension
+from hypergrid.grid import HGrid
 
-__all__ = ["Grid", "Dimension"]
+__all__ = ["HGrid", "Dimension", "FDimension", "IDimension"]

--- a/src/hypergrid/ext/sklearn.py
+++ b/src/hypergrid/ext/sklearn.py
@@ -3,10 +3,10 @@ try:
 except ImportError:
     raise ImportError("If using sklearn conversion functionality, install hypergrid with `sklearn` extras via `pip install hypergrid[sklearn]`")
 
-from hypergrid.grid import Grid, IGrid, ProductGrid
+from hypergrid.grid import Grid, HGrid, ProductGrid
 
 
-def _grid_to_sklearn(grid: IGrid) -> ParameterGrid:  # type: ignore[no-any-unimported]
+def _grid_to_sklearn(grid: Grid) -> ParameterGrid:  # type: ignore[no-any-unimported]
     """
     SKLearn's ParameterGrid accepts {str: sequence}
 
@@ -16,13 +16,13 @@ def _grid_to_sklearn(grid: IGrid) -> ParameterGrid:  # type: ignore[no-any-unimp
     return ParameterGrid(_grid_to_sklearn_recursive_helper(grid))
 
 
-def _grid_to_sklearn_recursive_helper(grid: IGrid) -> dict:
+def _grid_to_sklearn_recursive_helper(grid: Grid) -> dict:
     """
     SKLearn's param_grid dictionaries only support simple cartesian products, so only the Grid and ProductGrid elements
       are convertible to SKLearn parameter grids.
     """
     match grid:
-        case Grid():
+        case HGrid():
             # TODO: will OOM on infinite iterators
             return {dim.name: [v for v in dim] for dim in grid.dimensions}
         case ProductGrid():

--- a/tests/hypergrid/ext/test_sklearn.py
+++ b/tests/hypergrid/ext/test_sklearn.py
@@ -1,9 +1,9 @@
-from hypergrid.dsl import Grid
+from hypergrid.dsl import HGrid
 
 
 def test_basic_grid_sklearn_conversion():
-    g = Grid(test=[1, 2, 3])
-    g2 = Grid(test2=[4, 5, 6])
+    g = HGrid(test=[1, 2, 3])
+    g2 = HGrid(test2=[4, 5, 6])
     pg = (g * g2).to_sklearn()
     assert set(pg.param_grid[0].keys()) == {"test", "test2"}
     assert len([i for i in pg]) == 9

--- a/tests/hypergrid/test_dimension.py
+++ b/tests/hypergrid/test_dimension.py
@@ -1,20 +1,30 @@
+import itertools
+
 import pytest
 
-from hypergrid.dimension import Dimension
+from hypergrid.dimension import Dimension, FDimension, IDimension
 
 
-def test_base_dimension_construct():
-    dim = Dimension(test=[1, 2, 3])
+def test_fixed_dimension_construct():
+    dim = FDimension(test=[1, 2, 3])
     assert len(dim.values) == 3
     assert dim.name == "test"
 
-    dim = Dimension(test=range(4))
+    dim = FDimension(test=range(4))
     assert len(dim.values) == 4
 
     with pytest.raises(AssertionError):
-        Dimension(test1=[1, 2, 3], test2=[1, 2, 3])
+        FDimension(test1=[1, 2, 3], test2=[1, 2, 3])
 
 
-def test_base_dimension_iter():
-    dim = Dimension(test=[1, 2, 3])
+def test_fixed_dimension_iter():
+    dim = FDimension(test=[1, 2, 3])
     assert len([i for i in dim]) == 3
+
+
+def test_dimension_factory():
+    f = Dimension.make(test=[1, 2, 3])
+    assert isinstance(f, FDimension)
+
+    i = Dimension.make(test=itertools.count(start=0, step=1))
+    assert isinstance(i, IDimension)


### PR DESCRIPTION
Naming changes:

IDim -> Dim
IGrid -> Grid
Grid -> HGrid
Dim -> FDimension, IDimension

constructor distinguishes between collections (which primarily implement `__len__` and are finite) and arbitrary iterables.  This will be important since arbitrary iterables don't play well with grid conversion, etc.
